### PR TITLE
Prevent vimpandoc from running on main

### DIFF
--- a/.github/workflows/panvimdoc.yml
+++ b/.github/workflows/panvimdoc.yml
@@ -1,6 +1,9 @@
 name: panvimdoc
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - "main"
 
 jobs:
   docs:

--- a/doc/hydra.txt
+++ b/doc/hydra.txt
@@ -1,4 +1,4 @@
-*hydra.txt*            For NVIM v0.9.4           Last change: 2023 December 27
+*hydra.txt*            For NVIM v0.9.4           Last change: 2023 December 28
 
 ==============================================================================
 Table of Contents                                    *hydra-table-of-contents*


### PR DESCRIPTION
closes #11

I'm pretty sure that we don't want this action to run on main, instead we can just let it run in PRs and then the vimdoc changes will be merged like normal.
