### PR TITLE
fix(hint.statusline): Restore correct window if it changed

### DIFF
--- a/lua/hydra/hint/statusline.lua
+++ b/lua/hydra/hint/statusline.lua
@@ -42,12 +42,15 @@ function HintStatusLine:show()
    statusline = table.concat(statusline) ---@diagnostic disable-line
 
    self.original_statusline = vim.wo.statusline
+   self.winid = vim.api.nvim_get_current_win()
    vim.wo.statusline = statusline
 end
 
 function HintStatusLine:close()
    if self.original_statusline then
-      vim.wo.statusline = self.original_statusline
+      if vim.tbl_contains(vim.api.nvim_list_wins(), self.winid) then
+         vim.wo[self.winid].statusline = self.original_statusline
+      end
       self.original_statusline = nil
    end
 end


### PR DESCRIPTION
When the Hydra takes the user to a different window, we need to restore
the status line of the old window where the hint is shown.

---

Thanks for the fork! I'm copying my PRs over.

This was https://github.com/anuvyklack/hydra.nvim/pull/74
