### PR TITLE
fix(lib/highlight): Ignore invalid highlight keys

### DIFF
--- a/lua/hydra/lib/highlight.lua
+++ b/lua/hydra/lib/highlight.lua
@@ -3,7 +3,13 @@ local api = vim.api
 local function get_hl(name)
    ---@type boolean
    local rgb = api.nvim_get_option('termguicolors')
-   return api.nvim_get_hl_by_name(name, rgb)
+   local result = {}
+   for key, value in pairs(api.nvim_get_hl_by_name(name, rgb)) do
+      if type(key) == 'string' then
+         result[key] = value
+      end
+   end
+   return result
 end
 
 local name, settings

--- a/lua/hydra/lib/highlight.lua
+++ b/lua/hydra/lib/highlight.lua
@@ -1,22 +1,10 @@
 local api = vim.api
 
-local function get_hl(name)
-   ---@type boolean
-   local rgb = api.nvim_get_option('termguicolors')
-   local result = {}
-   for key, value in pairs(api.nvim_get_hl_by_name(name, rgb)) do
-      if type(key) == 'string' then
-         result[key] = value
-      end
-   end
-   return result
-end
-
 local name, settings
 for _, color in ipairs({ 'Red', 'Blue', 'Amaranth', 'Teal', 'Pink' }) do
    settings = vim.tbl_deep_extend('force',
-      get_hl('StatusLine'),
-      get_hl(string.format('Hydra%s', color))
+      api.nvim_get_hl(0, { name = 'StatusLine', link = false }),
+      api.nvim_get_hl(0, { name = string.format('Hydra%s', color), link = false })
    )
    name = string.format('HydraStatusLine%s', color)
    api.nvim_set_hl(0, name, settings)


### PR DESCRIPTION
If a user sets colour scheme to default after Neovim starts,
nvim_get_hl_by_name('HydraRed', true) returns { [true] = 6 }. This
causes an 'invalid key' error later when it's used in nvim_set_hl().

It is quite a rare case, and it should be fine as long as we can avoid
the error, so that Hydra still functions.

---

This was https://github.com/anuvyklack/hydra.nvim/pull/75
