### PR TITLE
feat: custom status line hints

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+
+[*]
+indent_style = space
+indent_size = 3

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Hydra({
 
 By default, a one line hint is generated and displayed in the cmdline. Heads and their
 descriptions are placed in the order they were passed into the `heads` table. Heads with
-`{opts = {desc = false}}` don't appear in auto-generated hints.
+`{ opts = { desc = false }}` don't appear in auto-generated hints.
 
 Values in the hint string are parsed with the following rules:
 
@@ -208,12 +208,12 @@ Values in the hint string are parsed with the following rules:
   inserted into the hint
   - Updated each time a head is called
   - Pass these functions to `config.hint.funcs` (discussed below)
-  - There are built-in functions located here: [this
-    file](https://github.com/nvimtools/hydra.nvim/blob/main/lua/hydra/hint/vim-options.lua)
+  - There are built-in functions located
+  [here](https://github.com/nvimtools/hydra.nvim/blob/main/lua/hydra/hint/vim-options.lua)
 
 **Heads not in the manually created hint, will be automatically added to the bottom of the
 hint window, following the same rules as auto-generated hint. You can avoid this with
-`{desc = false}`**
+`{ desc = false }`**
 
 ### Hint Configuration
 
@@ -225,10 +225,12 @@ Hydra({
     config = {
         -- either a table like below, or `false` to disable the hint
         hint = {
-            -- "window" | "cmdline" | "statusline"
-            --   "window"    : show hint in a floating window
-            --   "cmdline"   : show hint in the echo area
+            -- "window" | "cmdline" | "statusline" | "statuslinemanual"
+            --   "window": show hint in a floating window
+            --   "cmdline": show hint in the echo area
             --   "statusline": show auto-generated hint in the status line
+            --   "statuslinemanual": Do not show a hint, but return a custom status
+            --                       line hint from require("hydra.statusline").get_hint()
             type = "window", -- defaults to "window" if `hint` is passed to the hydra
                              -- otherwise defaults to "cmdline"
 
@@ -482,7 +484,7 @@ you to integrate Hydra in your statusline:
 - `get_name()` — get the name of an active hydra if it has it;
 - `get_color()` — get the color of an active hydra;
 - `get_hint()` — get an active hydra's statusline hint. Return not `nil` only when
-  `config.hint` is set to `false.`
+  `config.hint` is set to `false` or when `config.hint.type == "statuslinemanual"`
 
 ## Limitations
 

--- a/doc/hydra.txt
+++ b/doc/hydra.txt
@@ -1,4 +1,4 @@
-*hydra.txt*            For NVIM v0.9.4            Last change: 2024 January 06
+*hydra.txt*            For NVIM v0.9.4            Last change: 2024 January 10
 
 ==============================================================================
 Table of Contents                                    *hydra-table-of-contents*
@@ -205,7 +205,7 @@ The string for the hint is passed directly to the hydra:
 
 By default, a one line hint is generated and displayed in the cmdline. Heads
 and their descriptions are placed in the order they were passed into the
-`heads` table. Heads with `{opts = {desc = false}}` don’t appear in
+`heads` table. Heads with `{ opts = { desc = false }}` don’t appear in
 auto-generated hints.
 
 Values in the hint string are parsed with the following rules:
@@ -218,12 +218,12 @@ Values in the hint string are parsed with the following rules:
     inserted into the hint
     - Updated each time a head is called
     - Pass these functions to `config.hint.funcs` (discussed below)
-    - There are built-in functions located here: this
-        file <https://github.com/nvimtools/hydra.nvim/blob/main/lua/hydra/hint/vim-options.lua>
+    - There are built-in functions located
+        here <https://github.com/nvimtools/hydra.nvim/blob/main/lua/hydra/hint/vim-options.lua>
 
 **Heads not in the manually created hint, will be automatically added to the
 bottom of the hint window, following the same rules as auto-generated hint. You
-can avoid this with {desc = false}**
+can avoid this with { desc = false }**
 
 
 HINT CONFIGURATION                             *hydra-hint-hint-configuration*
@@ -236,10 +236,12 @@ disable the hint by setting this value to `false`.
         config = {
             -- either a table like below, or `false` to disable the hint
             hint = {
-                -- "window" | "cmdline" | "statusline"
-                --   "window"    : show hint in a floating window
-                --   "cmdline"   : show hint in the echo area
+                -- "window" | "cmdline" | "statusline" | "statuslinemanual"
+                --   "window": show hint in a floating window
+                --   "cmdline": show hint in the echo area
                 --   "statusline": show auto-generated hint in the status line
+                --   "statuslinemanual": Do not show a hint, but return a custom status
+                --                       line hint from require("hydra.statusline").get_hint()
                 type = "window", -- defaults to "window" if `hint` is passed to the hydra
                                  -- otherwise defaults to "cmdline"
     
@@ -506,7 +508,7 @@ can help you to integrate Hydra in your statusline:
 - `get_name()` — get the name of an active hydra if it has it;
 - `get_color()` — get the color of an active hydra;
 - `get_hint()` — get an active hydra’s statusline hint. Return not `nil` only when
-    `config.hint` is set to `false.`
+    `config.hint` is set to `false` or when `config.hint.type == "statuslinemanual"`
 
 
 ==============================================================================

--- a/lua/hydra/hint/init.lua
+++ b/lua/hydra/hint/init.lua
@@ -8,7 +8,8 @@ local HintManualCmdline = cmdline.HintManualCmdline
 local HintAutoWindow = window.HintAutoWindow
 local HintManualWindow = window.HintManualWindow
 
-local HintStatusLine = statusline.HintStatusLine
+local HintAutoStatusLine = statusline.HintAutoStatusLine
+local HintManualStatusLine = statusline.HintManualStatusLine
 local HintStatusLineMute = statusline.HintStatusLineMute
 
 ---@return hydra.Hint
@@ -19,12 +20,16 @@ local function make_hint(input)
       return HintStatusLineMute(input)
    elseif hint and config.type == 'window' then
       return HintManualWindow(input)
+   elseif hint and config.type == 'statusline' then
+      return HintManualStatusLine(input)
+   elseif hint and config.type == 'statuslinemanual' then
+      return HintStatusLineMute(input)
    elseif hint then
       return HintManualCmdline(input)
    elseif config.type == 'cmdline' then
       return HintAutoCmdline(input)
    elseif config.type == 'statusline' then
-      return HintStatusLine(input)
+      return HintAutoStatusLine(input)
    elseif config.type == 'window' then
       return HintAutoWindow(input)
    end

--- a/lua/hydra/hint/parser.lua
+++ b/lua/hydra/hint/parser.lua
@@ -1,0 +1,55 @@
+local Parser = {}
+
+---Evaluate function values
+---@param line string
+---@param funcs table
+---@return string
+---@return boolean
+function Parser.eval_funcs(line, funcs)
+  local start, stop, fname = 0, nil, nil
+  local need_to_update = false
+  while start do
+    start, stop, fname = line:find("%%{(.-)}", 1)
+    if start then
+      need_to_update = true
+
+      local fun = funcs[fname]
+      if not fun then
+        error(string.format('[Hydra] "%s" not present in "config.hint.functions" table', fname))
+      end
+
+      line = table.concat({
+        line:sub(1, start - 1),
+        fun(),
+        line:sub(stop + 1),
+      })
+    end
+  end
+
+  return line, need_to_update
+end
+
+---Parse the heads in a hint string, adding highlights with the given function
+--- modifies the heads table
+---@param line string
+---@param heads table
+---@param highlight function
+Parser.parse_heads = function(line, heads, highlight)
+  local start, stop, head = 0, 0, nil
+  while start do
+    start, stop, head = line:find('_(.-)_', stop + 1)
+    if head and vim.startswith(head, [[\]]) then head = head:sub(2) end
+    if start then
+      if not heads[head] then
+        error(string.format('[Hydra] docsting error, head "%s" does not exist', head))
+      end
+      local color = heads[head].color
+      -- TODO: create this function. and pass it.
+      -- buffer:add_highlight(namespace, 'Hydra' .. color, n - 1, start, stop - 1)
+      highlight(color, start, stop - 1)
+      heads[head] = nil
+    end
+  end
+end
+
+return Parser

--- a/lua/hydra/hint/statusline.lua
+++ b/lua/hydra/hint/statusline.lua
@@ -2,15 +2,16 @@ local class = require('hydra.lib.class')
 local BaseHint = require('hydra.hint.basehint')
 local M = {}
 
+---Auto generated status line
 ---@class hydra.hint.StatusLine : hydra.Hint
 ---@field update nil
-local HintStatusLine = class(BaseHint)
+local HintAutoStatusLine = class(BaseHint)
 
-function HintStatusLine:initialize(input)
+function HintAutoStatusLine:initialize(input)
    BaseHint.initialize(self, input)
 end
 
-function HintStatusLine:_make_statusline()
+function HintAutoStatusLine:_make_statusline()
    if self.statusline then return end
 
    require('hydra.lib.highlight')
@@ -32,7 +33,7 @@ function HintStatusLine:_make_statusline()
    self.statusline = statusline:gsub(', $', '')
 end
 
-function HintStatusLine:show()
+function HintAutoStatusLine:show()
    if not self.statusline then self:_make_statusline() end
 
    local statusline = { ' ', self.statusline } ---@type string[]
@@ -45,7 +46,7 @@ function HintStatusLine:show()
    vim.wo.statusline = statusline
 end
 
-function HintStatusLine:close()
+function HintAutoStatusLine:close()
    if self.original_statusline then
       vim.wo.statusline = self.original_statusline
       self.original_statusline = nil
@@ -54,13 +55,67 @@ end
 
 --------------------------------------------------------------------------------
 
+---Statusline with custom hint string
+---@class hydra.hint.ManualStatusLine : hydra.hint.StatusLine
+---@field need_to_update boolean
+local HintManualStatusLine = class(HintAutoStatusLine)
+
+function HintManualStatusLine:initialize(input)
+   HintAutoStatusLine.initialize(self, input)
+   self.need_to_update = false
+end
+
+function HintManualStatusLine:_make_statusline()
+   if self.statusline then return end
+   if not self.hint then return HintAutoStatusLine._make_statusline(self) end
+
+   require('hydra.lib.highlight')
+   local parser = require("hydra.hint.parser")
+
+   ---@type string
+   local hint = self.hint
+   hint = hint:gsub("%^", "")
+
+   ---@type table<string, hydra.HeadSpec>
+   local heads = vim.deepcopy(self.heads)
+
+   ---@type string[]
+   local statusline = {}
+
+   -- eval funcs
+   local parsed_line, need_to_update = parser.eval_funcs(hint, self.config.funcs)
+   self.need_to_update = self.need_to_update or need_to_update
+   hint = parsed_line
+
+   local last_end = nil
+   parser.parse_heads(hint, heads, function(color, start, end_)
+      if last_end ~= nil then
+         vim.list_extend(statusline, {
+            hint:sub(last_end + 2, start - 1)
+         })
+      end
+      local head_key = hint:sub(start + 1, end_)
+      vim.list_extend(statusline, {
+         string.format('%%#HydraStatusLine%s#', color),
+         head_key,
+         '%#StatusLine#',
+      })
+      last_end = end_
+   end)
+
+   statusline = table.concat(statusline) ---@diagnostic disable-line
+   self.statusline = statusline
+end
+
+--------------------------------------------------------------------------------
+
 ---Statusline hint that won't be shown. It is used in "hydra.statusline" module.
----@class hydra.hint.StatusLineMute : hydra.hint.StatusLine
+---@class hydra.hint.StatusLineMute : hydra.hint.ManualStatusLine
 ---@field config nil
-local HintStatusLineMute = class(HintStatusLine)
+local HintStatusLineMute = class(HintManualStatusLine)
 
 function HintStatusLineMute:initialize(input)
-   HintStatusLine.initialize(self, input)
+   HintManualStatusLine.initialize(self, input)
 end
 
 ---@param do_return? boolean Do return statusline hint string?
@@ -74,6 +129,7 @@ end
 
 --------------------------------------------------------------------------------
 
-M.HintStatusLine = HintStatusLine
+M.HintAutoStatusLine = HintAutoStatusLine
+M.HintManualStatusLine = HintManualStatusLine
 M.HintStatusLineMute = HintStatusLineMute
 return M

--- a/lua/hydra/hint/statusline.lua
+++ b/lua/hydra/hint/statusline.lua
@@ -60,9 +60,16 @@ end
 ---@field need_to_update boolean
 local HintManualStatusLine = class(HintAutoStatusLine)
 
+local vim_options = require('hydra.hint.vim-options')
 function HintManualStatusLine:initialize(input)
    HintAutoStatusLine.initialize(self, input)
    self.need_to_update = false
+
+   if type(self.config) == "table" then
+      self.config.funcs = setmetatable(self.config.funcs or {}, {
+         __index = vim_options
+      })
+   end
 end
 
 function HintManualStatusLine:_make_statusline()
@@ -103,8 +110,24 @@ function HintManualStatusLine:_make_statusline()
       last_end = end_
    end)
 
+   vim.list_extend(statusline, {
+      hint:sub(last_end + 2)
+   })
+
    statusline = table.concat(statusline) ---@diagnostic disable-line
    self.statusline = statusline
+end
+
+function HintManualStatusLine:update()
+   print("hi")
+   if not self.need_to_update then return end
+   print("need to update")
+
+   local saved_statusline = self.original_statusline
+   self.statusline = nil
+   self:_make_statusline()
+   self:show()
+   self.original_statusline = saved_statusline
 end
 
 --------------------------------------------------------------------------------

--- a/lua/hydra/lib/types.lua
+++ b/lua/hydra/lib/types.lua
@@ -31,7 +31,7 @@
 ---@field hint? hydra.hint.OptionalConfig | false
 
 ---@class hydra.hint.Config
----@field type 'statusline' | 'cmdline' | 'window' | nil
+---@field type 'statusline' | 'cmdline' | 'window' | 'manualstatusline' | nil
 ---@field position hydra.hint.Config.position
 ---@field offset integer
 ---@field border? string | table -- deprecated, use `float_opts.border`

--- a/lua/hydra/statusline.lua
+++ b/lua/hydra/statusline.lua
@@ -15,13 +15,14 @@ end
 ---Get an active Hydra's statusline hint if it provides it
 ---@return string?
 function statusline.get_hint()
-   if _G.Hydra and _G.Hydra.config.hint == false then
+   local hint_type = _G.Hydra.config.hint and _G.Hydra.config.hint.type
+   if _G.Hydra and _G.Hydra.config.hint == false or hint_type == "statuslinemanual" or hint_type == "statusline" then
       return _G.Hydra.hint:show(true)
    end
 end
 
----Get the color of an active Hydra
----@return string
+---Get the color of an active Hydra, or nil if there is no active hydra
+---@return string | nil
 function statusline.get_color()
    return _G.Hydra and string.lower(_G.Hydra.config.color)
 end


### PR DESCRIPTION
closes #20

## Features
- Allows users to pass a `hint` to a hydra when `config.hint.type = "statusline"`. The hint is parsed and highlighted using the same rules as window hints
- Adds `"statuslinemanual"` hint type to enable passing a hint string while not automatically showing a hint in the status line (the same way setting `config.hint = false` does for a normal auto generated status line. Issue is when you pass a hint, the type is assumed to be `window`, so we need this new type if we don't want to change behavior).

Done in two steps if you would like to review the PR that way:
- chore: window hint parsing
- feat: custom status line hints

This PR also fixes a few README problems that I found, and adds an `.editorconfig` file b/c the majority of the codebase uses 3-space tabs so I'm setting that as the default.

This PR **does not** currently append unused heads to the end of a manual status line hint. I can add that I guess if we care to be consistent.

<details>
  <summary>Example of what you can now do:</summary>
  
```lua
Hydra({
  name = "QuartoNavigator",
  hint = "_j_/_k_: ↑/↓ | _o_/_O_: new cell ↓/↑ | _l_: run | _s_how | _h_ide | run _a_bove | _q_uit",
  config = {
    color = "pink",
    invoke_on_body = true,
    hint = {
      type = "statuslinemanual",
    },
  },
  mode = { "n" },
  body = "<localleader>j",
  heads = {
    { "j", keys("]b"), { desc = "↓" } },
    { "k", keys("[b"), { desc = "↑" } },
    { "o", keys("/```<CR>:nohl<CR>o<CR>`<c-j>"), { desc = "new cell ↓", exit = true } },
    { "O", keys("?```.<CR>:nohl<CR><leader>kO<CR>`<c-j>"), { desc = "new cell ↑", exit = true } },
    { "l", ":QuartoSend<CR>", { desc = "run" } },
    { "s", ":noautocmd MoltenEnterOutput<CR>", { desc = "show" } },
    { "h", ":MoltenHideOutput<CR>", { desc = "hide" } },
    { "a", ":QuartoSendAbove<CR>", { desc = "run above" } },
    { "<esc>", nil, { exit = true, desc = false } },
    { "q", nil, { exit = true, desc = false } },
  },
})

-- in addition to some status line code which calls `require("hydra.statusline").get_hint()`
```

![image](https://github.com/nvimtools/hydra.nvim/assets/56943754/2c416be3-8ebb-4c8b-8368-242b47f1ee8c)


</details>

## TODO:
- [x] Function Values in the status line