### PR TITLE
ensure that Layer:_normalize_input returns non-nil tables

### DIFF
--- a/lua/hydra/layer/init.lua
+++ b/lua/hydra/layer/init.lua
@@ -334,6 +334,8 @@ function Layer:_normalize_input(enter, layer, exit)
          end
          util.deep_unsetmetatable(k)
          r[i] = k
+      else
+         r[i] = {} -- later functions assume that r[1|2|3] are tables
       end
    end
    return r[1], r[2], r[3]


### PR DESCRIPTION
This prevents a runtime error in  when a Hydra is defined that only has heads where `exit = true` which causes `layer_keymaps` to be nil. Further on in hydra/layer/init `layer_keymaps` is assumed to be non-nil.

Reproducing is pretty simple. You can try creating a Hydra like this and it should error without my fix:
```lua
require("hydra")({
      mode = "t",
      config = {
        color = "pink",
        buffer = true,
      },
      heads = {
        { "q", function() api.nvim_feedkeys("q", 'i', false) end,
          { desc = "Close", exit_before = true, }, },
      },
    }):activate()
```
![image](https://github.com/nvimtools/hydra.nvim/assets/3179363/f9a0b877-0764-4023-8c7d-33443a1965d6)
