### PR TITLE
Fix an error in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,10 @@ sets them in the following way:
 | pink     | foreign_keys = 'run'               |
 
 > [!NOTE]
-> The `exit` and `foreign_keys` options are higher priority than the `color` option and
-> can't be overridden by it. I.e, if manually set values of `exit` and `foreign_keys`
-> contradict the `color` value, then the `color` value is ignored
+> `Color` has higher precedence than the `exit` and `foreign_keys` options. 
+> If the values specified in the `exit` or `foreign_keys` options conflict with the 
+> ones implied by `color`, the `exit` or `foreign_keys` options are ignored.
+
 
 Colors are also used to highlight heads in the hint, so you know how they will behave.
 


### PR DESCRIPTION
The readme currently says:
> The exit and foreign_keys options are higher priority than the color option

However, this is the opposite of what the plugin does:
```lua
      -- Bring 'foreign_keys', 'exit' and 'color' options into line.
      -- `Color` has higher precedence. If passed `color` not equal to
      -- one derived from passed `foreign-keys` and `exit` options, then
      -- override them.
      if self.config.color ~= util.get_color_from_config(self.config.foreign_keys, self.config.exit) then
         self.config.foreign_keys, self.config.exit = util.get_config_from_color(self.config.color)
      end
```