### PR TITLE
fix: allow layers to have names and trigger status line active function

### DIFF
--- a/doc/hydra.txt
+++ b/doc/hydra.txt
@@ -1,4 +1,4 @@
-*hydra.txt*             For NVIM v0.9.4             Last change: 2025 March 26
+*hydra.txt*             For NVIM v0.9.4             Last change: 2025 April 28
 
 ==============================================================================
 Table of Contents                                    *hydra-table-of-contents*

--- a/lua/hydra/init.lua
+++ b/lua/hydra/init.lua
@@ -361,12 +361,13 @@ function Hydra:_setup_hydra_keymaps()
 end
 
 function Hydra:_setup_pink_hydra()
-   local layer = { enter = {}, layer = {}, exit = {} }
+   local layer = { name = self.name, enter = {}, layer = {}, exit = {} }
    layer.config = {
       debug = self.config.debug,
       desc = self.config.desc,
       buffer = self.config.buffer,
       timeout = self.config.timeout,
+      hint = self.config.hint,
       on_key = function()
          if self.hint.update then self.hint:update() end
          if self.config.on_key then self.config.on_key() end

--- a/lua/hydra/layer/init.lua
+++ b/lua/hydra/layer/init.lua
@@ -47,6 +47,7 @@ local autocmd = api.nvim_create_autocmd
 _G.active_keymap_layer = nil
 
 ---@class hydra.Layer
+---@field name string
 ---@field active boolean
 ---@field config hydra.layer.Config
 ---@field enter_keymaps table
@@ -70,6 +71,7 @@ function Layer:initialize(input)
    self.active = false
    self.id = util.generate_id() -- Unique ID for each Layer.
    self.config = input.config or {}
+   self.name = input.name
    if self.config.timeout == true then
       self.config.timeout = vim.o.timeoutlen
    end

--- a/lua/hydra/statusline.lua
+++ b/lua/hydra/statusline.lua
@@ -3,20 +3,21 @@ local statusline = {}
 ---Returns `true` if there is an active hydra
 ---@return boolean
 function statusline.is_active()
-   return _G.Hydra and true or false
+   return (_G.Hydra or _G.active_keymap_layer) and true or false
 end
 
 ---Get the name of an active Hydra if it has it
 ---@return string | nil
 function statusline.get_name()
-   return _G.Hydra and _G.Hydra.name
+   return (_G.Hydra and _G.Hydra.name) or (_G.active_keymap_layer and _G.active_keymap_layer.name)
 end
 
 ---Get an active Hydra's statusline hint if it provides it
 ---@return string?
 function statusline.get_hint()
+   if not _G.Hydra then return end
    local hint_type = _G.Hydra.config.hint and _G.Hydra.config.hint.type
-   if _G.Hydra and _G.Hydra.config.hint == false or hint_type == "statuslinemanual" or hint_type == "statusline" then
+   if _G.Hydra.config.hint == false or hint_type == "statuslinemanual" or hint_type == "statusline" then
       return _G.Hydra.hint:show(true)
    end
 end
@@ -24,7 +25,7 @@ end
 ---Get the color of an active Hydra, or nil if there is no active hydra
 ---@return string | nil
 function statusline.get_color()
-   return _G.Hydra and string.lower(_G.Hydra.config.color)
+   return (_G.Hydra and string.lower(_G.Hydra.config.color)) or (_G.active_keymap_layer and "pink")
 end
 
 return statusline


### PR DESCRIPTION
fix #63 

This issue is a side effect of layers and regular hydras being totally different implementations, there are a lot of inconsistencies between the two.

pink hydras don't have hints, as an additional example